### PR TITLE
Store average time of day not timestamp

### DIFF
--- a/exe/backend/src/main.cc
+++ b/exe/backend/src/main.cc
@@ -244,7 +244,7 @@ int main(int argc, char const* argv[]) {
                                         std::chrono::system_clock::time_point(
                                             std::chrono::seconds(
                                                 update.arrival().time())))),
-                    update.arrival().time()};
+                    update.arrival().time() % 86400};
                   stopTimes.push_back(stopTime);
                 }
               }

--- a/src/predictors/historic-average-predictor.cc
+++ b/src/predictors/historic-average-predictor.cc
@@ -57,7 +57,7 @@ void HistoricAveragePredictor::predict(
         const auto distance = bg::distance(vehicle_point, locationPoint, bg::strategy::distance::haversine(6371000.0));
 
         if (distance < 100) {
-          this->store_.store(tripID, location.id_.data(), current_time, today);
+          this->store_.store(tripID, location.id_.data(), current_time % 86400, today);
         }
       }
     }
@@ -119,6 +119,11 @@ void HistoricAveragePredictor::predict(
       transit_realtime::TripUpdate_StopTimeEvent* arrivalToUpdate = stop_time_update->mutable_arrival();
 
       tripUpdateToUpdate->set_timestamp(current_time);
+      struct tm* localTime = localtime(&current_time);
+      localTime->tm_hour = 0;
+      localTime->tm_min = 0;
+      localTime->tm_sec = 0;
+      arrival_time = arrival_time + mktime(localTime);
       arrivalToUpdate->set_time(arrival_time);
       arrivalToUpdate->set_uncertainty(0);
     }
@@ -135,6 +140,6 @@ void HistoricAveragePredictor::loadHistoricData(const std::vector<stopTime>& sto
   for (stopTime stopTime : stopTimes) {
     std::ostringstream oss;
     oss << std::put_time(&tm, "%d-%m-%Y %H-%M-%S");
-    this->store_.store(stopTime.trip_id, stopTime.stop_id, stopTime.arrival_time, oss.str());
+    this->store_.store(stopTime.trip_id, stopTime.stop_id, stopTime.arrival_time % 86400, oss.str());
   }
 }

--- a/test/store_test.cc
+++ b/test/store_test.cc
@@ -4,12 +4,12 @@
 TEST(StoreTest, CompleteTest) {
   stopTimeStore store;
 
-  // Unix-Zeitstempel für den 20. März 2024, 12:00 Uhr
-  constexpr int64_t time1 = 1710931200;  // 2024-03-20 12:00:00
-  // Unix-Zeitstempel für den 20. März 2024, 12:10 Uhr
-  constexpr int64_t time2 = 1710931800;  // 2024-03-20 12:10:00
-  // Unix-Zeitstempel für den 20. März 2024, 12:20 Uhr
-  constexpr int64_t time3 = 1710932400;  // 2024-03-20 12:20:00
+  // Zeitstempel für 12:00 Uhr
+  constexpr int64_t time1 = 38400;  // 12:00:00
+  // Zeitstempel für 12:10 Uhr
+  constexpr int64_t time2 = 39000;  // 12:10:00
+  // Zeitstempel für 12:20 Uhr
+  constexpr int64_t time3 = 39600;  // 12:20:00
 
   store.store("trip1", "stop1", time1, "2024-03-20");
   store.store("trip1", "stop1", time2, "2024-03-21");
@@ -17,7 +17,7 @@ TEST(StoreTest, CompleteTest) {
 
   // Test für trip1/stop1 - Durchschnitt von time1 und time2
   const int64_t averageTime = store.getAverageArrivalTime("trip1", "stop1");
-  EXPECT_EQ(averageTime, 1710931500);  // (1710931200 + 1710931800) / 2
+  EXPECT_EQ(averageTime, 38700);  // (39000 + 38400) / 2
 
   // Test für trip2/stop1 - Sollte exakt time3 sein
   const int64_t singleTime = store.getAverageArrivalTime("trip2", "stop1");


### PR DESCRIPTION
Instead of storing and averages timestamps only store and average time of day.

Otherwise, the average of the timestamps from yesterday and the day before is in the middle of the night, which is not what we want to predict. We only want the average time of day and add it to the current day to get a prediction